### PR TITLE
retrieve-geps-forecasts job: match new config from script and avoid repeated env var

### DIFF
--- a/scheduler-jobs/retrieve_geps_forecasts.env
+++ b/scheduler-jobs/retrieve_geps_forecasts.env
@@ -32,9 +32,20 @@ fi
 #RETRIEVE_GEPS_FORECASTS_GIT_SSH_IDENTITY_FILE=/home/vagrant/.ssh/id_rsa_git_ssh_read_only
 
 # OPTIONAL to override behavior of pavics-vdb/ECCC-datamart_sync/run_convert_grib2_to_nc
-#RUN_CONVERT_GRIB2_TO_NC_INPATH="/data/tmp/geps_forecast/grib2"
-#RUN_CONVERT_GRIB2_TO_NC_OUTPATH="/data/tmp/geps_forecast/netcdf"
-#RUN_CONVERT_GRIB2_TO_NC_THREDDSPATH="/pvcs1/DATA/eccc/forecasts/geps"
+#CONVERT_GRIB2_TO_NC_INPATH="/data/tmp/geps_forecast/grib2"
+#CONVERT_GRIB2_TO_NC_OUTPATH="/data/tmp/geps_forecast/netcdf"
+#CONVERT_GRIB2_TO_NC_THREDDSPATH="/pvcs1/DATA/eccc/forecasts/geps"
+
+# Disable progress bar to avoid spamming logs file.
+CONVERT_GRIB2_TO_NC_PROGRESSBAR="false"
+
+CONFIG_ENV_VAR_LIST=" \
+    CONVERT_GRIB2_TO_NC_INPATH \
+    CONVERT_GRIB2_TO_NC_OUTPATH \
+    CONVERT_GRIB2_TO_NC_THREDDSPATH \
+    CONVERT_GRIB2_TO_NC_PROGRESSBAR \
+"
+
 
 ##############################################################################
 # End configuration vars
@@ -55,6 +66,12 @@ if [ -z "`echo "$AUTODEPLOY_EXTRA_SCHEDULER_JOBS" | grep retrieve_geps_forecasts
     --env DEPLOY_DATA_GIT_SSH_IDENTITY_FILE=${RETRIEVE_GEPS_FORECASTS_GIT_SSH_IDENTITY_FILE}"
     fi
 
+    EXTRA_DOCKER_ENV_ARGS=""
+    for var in $CONFIG_ENV_VAR_LIST; do
+        EXTRA_DOCKER_ENV_ARGS="$EXTRA_DOCKER_ENV_ARGS
+    `eval echo "--env $var=\\$$var"`"
+    done
+
     export AUTODEPLOY_EXTRA_SCHEDULER_JOBS="
 $AUTODEPLOY_EXTRA_SCHEDULER_JOBS
 
@@ -69,11 +86,8 @@ $AUTODEPLOY_EXTRA_SCHEDULER_JOBS
     --volume ${RETRIEVE_GEPS_FORECASTS_CONFIG}:${RETRIEVE_GEPS_FORECASTS_CONFIG}:ro
     --volume ${RETRIEVE_GEPS_FORECASTS_CHECKOUT_CACHE}:${RETRIEVE_GEPS_FORECASTS_CHECKOUT_CACHE}:rw
     --volume ${LOGFILE_DIRNAME}:${LOGFILE_DIRNAME}:rw
-    --env RUN_CONVERT_GRIB2_TO_NC_INPATH=${RUN_CONVERT_GRIB2_TO_NC_INPATH}
-    --env RUN_CONVERT_GRIB2_TO_NC_OUTPATH=${RUN_CONVERT_GRIB2_TO_NC_OUTPATH}
-    --env RUN_CONVERT_GRIB2_TO_NC_THREDDSPATH=${RUN_CONVERT_GRIB2_TO_NC_THREDDSPATH}
     --env DEPLOY_DATA_CHECKOUT_CACHE=${RETRIEVE_GEPS_FORECASTS_CHECKOUT_CACHE}
-    --env DEPLOY_DATA_LOGFILE=${RETRIEVE_GEPS_FORECASTS_LOGFILE} ${EXTRA_DOCKER_ARGS}
+    --env DEPLOY_DATA_LOGFILE=${RETRIEVE_GEPS_FORECASTS_LOGFILE} ${EXTRA_DOCKER_ARGS} ${EXTRA_DOCKER_ENV_ARGS}
   image: 'docker:19.03.6-git'
 "
 

--- a/scheduler-jobs/retrieve_geps_forecasts.yml
+++ b/scheduler-jobs/retrieve_geps_forecasts.yml
@@ -9,12 +9,7 @@ deploy:
   branch: origin/master
   checkout_name: pavics-vdb-for-geps-forecasts
   post_actions:
-  - action: >-
-      RUN_CONVERT_GRIB2_TO_NC_INPATH=${RUN_CONVERT_GRIB2_TO_NC_INPATH}
-      RUN_CONVERT_GRIB2_TO_NC_OUTPATH=${RUN_CONVERT_GRIB2_TO_NC_OUTPATH}
-      RUN_CONVERT_GRIB2_TO_NC_THREDDSPATH=${RUN_CONVERT_GRIB2_TO_NC_THREDDSPATH}
-      CONVERT_GRIB2_TO_NC_PROGRESSBAR=false
-      ECCC-datamart_sync/run_convert_grib2_to_nc
+  - action: ECCC-datamart_sync/run_convert_grib2_to_nc
 
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2


### PR DESCRIPTION
For matching PR https://github.com/Ouranosinc/pavics-vdb/pull/23.

So the list of path env var name is repeated here again but at least the default values are not repeated.

Don't think I can move this list here.  It acts as command-line options so the caller can not not know about it.