### PR TITLE
Sample code to bypass twitcher to debug performance raven process timeout

### DIFF
--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -8,3 +8,7 @@ services:
   raven:
     volumes:
     - ../../birdhouse-deploy-ouranos/ouranos-config/raven/wps.cfg:/wps.cfg:ro
+
+  proxy:
+    volumes:
+    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/public-raven-bypass-twitcher.conf:/etc/nginx/conf.extra-service.d/raven/public-raven-bypass-twitcher.conf

--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -9,6 +9,7 @@ services:
     volumes:
     - ../../birdhouse-deploy-ouranos/ouranos-config/raven/wps.cfg:/wps.cfg:ro
 
-#  proxy:
-#    volumes:
-#    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/public-raven-bypass-twitcher.conf:/etc/nginx/conf.extra-service.d/raven/public-raven-bypass-twitcher.conf
+  proxy:
+    volumes:
+#    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/public-raven-bypass-twitcher.conf:/etc/nginx/conf.extra-service.d/raven/public-raven-bypass-twitcher.conf:ro
+     - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/increase-proxy_read_timeout.conf:/etc/nginx/conf.extra.d/proxy/increase-proxy_read_timeout.conf:ro

--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -9,10 +9,9 @@ services:
     volumes:
     - ../../birdhouse-deploy-ouranos/ouranos-config/raven/wps.cfg:/wps.cfg:ro
 
-  proxy:
-    volumes:
+#  proxy:
+#    volumes:
 # This raven bypass Twitcher is for debugging only, should not be enabled
 # permanently in prod.  Keep here as sample code and documentation how it can
 # be done.
 #    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/public-raven-bypass-twitcher.conf:/etc/nginx/conf.extra-service.d/raven/public-raven-bypass-twitcher.conf:ro
-     - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/increase-proxy_read_timeout.conf:/etc/nginx/conf.extra.d/proxy/increase-proxy_read_timeout.conf:ro

--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -9,6 +9,6 @@ services:
     volumes:
     - ../../birdhouse-deploy-ouranos/ouranos-config/raven/wps.cfg:/wps.cfg:ro
 
-  proxy:
-    volumes:
-    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/public-raven-bypass-twitcher.conf:/etc/nginx/conf.extra-service.d/raven/public-raven-bypass-twitcher.conf
+#  proxy:
+#    volumes:
+#    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/public-raven-bypass-twitcher.conf:/etc/nginx/conf.extra-service.d/raven/public-raven-bypass-twitcher.conf

--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -11,5 +11,8 @@ services:
 
   proxy:
     volumes:
+# This raven bypass Twitcher is for debugging only, should not be enabled
+# permanently in prod.  Keep here as sample code and documentation how it can
+# be done.
 #    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/public-raven-bypass-twitcher.conf:/etc/nginx/conf.extra-service.d/raven/public-raven-bypass-twitcher.conf:ro
      - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/increase-proxy_read_timeout.conf:/etc/nginx/conf.extra.d/proxy/increase-proxy_read_timeout.conf:ro

--- a/ouranos-config/proxy/.gitignore
+++ b/ouranos-config/proxy/.gitignore
@@ -1,0 +1,1 @@
+public-raven-bypass-twitcher.conf

--- a/ouranos-config/proxy/increase-proxy_read_timeout.conf
+++ b/ouranos-config/proxy/increase-proxy_read_timeout.conf
@@ -1,0 +1,1 @@
+    proxy_read_timeout 360s;  # default 60s

--- a/ouranos-config/proxy/increase-proxy_read_timeout.conf
+++ b/ouranos-config/proxy/increase-proxy_read_timeout.conf
@@ -1,1 +1,0 @@
-    proxy_read_timeout 360s;  # default 60s

--- a/ouranos-config/proxy/public-raven-bypass-twitcher.conf.template
+++ b/ouranos-config/proxy/public-raven-bypass-twitcher.conf.template
@@ -1,0 +1,6 @@
+    location /raven/ {
+	proxy_pass http://${PAVICS_FQDN}:8096/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }


### PR DESCRIPTION
Just commented out sample code.  Keep as a form of documentation how each organization can customize PAVICS deployment.

Used in https://github.com/bird-house/birdhouse-deploy/pull/123 for testing.