### PR TITLE
Deploy PAVICS-landing notebooks to Jupyter env

### DIFF
--- a/scheduler-jobs/deploy_pavics_landing_notebooks.env
+++ b/scheduler-jobs/deploy_pavics_landing_notebooks.env
@@ -1,0 +1,27 @@
+# Source this file in env.local before sourcing deploy_data_job.env.
+# This will configure deploy_data_job.env.
+
+#############
+## Sample way to override default configs in this file.
+#
+## Source this file providing default config values.
+#. <path to this file>
+#
+## Override cron schedule and set ssh identity file.
+#DEPLOY_DATA_JOB_SCHEDULE="3 0,3,6,9,12,15,18,21 * * *"  # UTC
+#DEPLOY_DATA_JOB_GIT_SSH_IDENTITY_FILE=/home/vagrant/.ssh/id_rsa_pavics-landing-ro
+#
+## Source deploy_data_job.env that will actually perform the job creation.
+#. <path to deploy_data_job.env>
+#
+## End Sample
+#############
+
+
+DEPLOY_DATA_JOB_SCHEDULE="17 * * * *"  # UTC
+DEPLOY_DATA_JOB_JOB_NAME="deploy_pavics_landing_notebooks"
+DEPLOY_DATA_JOB_CONFIG="${COMPOSE_DIR}/../../birdhouse-deploy-ouranos/scheduler-jobs/${DEPLOY_DATA_JOB_JOB_NAME}.yml"
+DEPLOY_DATA_JOB_JOB_DESCRIPTION="Deploy notebooks for the PAVICS landing page."
+
+
+# vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/scheduler-jobs/deploy_pavics_landing_notebooks.yml
+++ b/scheduler-jobs/deploy_pavics_landing_notebooks.yml
@@ -1,0 +1,17 @@
+# Config file for deploy-data script.
+#
+# Use in deploy_pavics_landing_notebooks.env scheduler job.
+#
+
+deploy:
+  # clone over ssh since private repo
+- repo_url: git@github.com:Ouranosinc/PAVICS-landing.git
+  branch: origin/master
+  checkout_name: PAVICS-landing
+  dir_maps:
+  # rsync content below source_dir into dest_dir
+  - source_dir: content/notebooks/climate_indicators
+    dest_dir: /data/jupyterhub_user_data/pavics-homepage
+
+
+# vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/scheduler-jobs/deploy_pavics_landing_notebooks.yml
+++ b/scheduler-jobs/deploy_pavics_landing_notebooks.yml
@@ -12,6 +12,7 @@ deploy:
   # rsync content below source_dir into dest_dir
   - source_dir: content/notebooks/climate_indicators
     dest_dir: /data/jupyterhub_user_data/pavics-homepage
+    rsync_extra_opts: --include=*/ --include=*.ipynb --include=*.geojson --exclude=*
 
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2


### PR DESCRIPTION
For issue https://github.com/Ouranosinc/PAVICS-landing/issues/19.

Need updated Jupyter env https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/68.

Given the PAVICS-landing is a private repo, I was not able to hook into the existing notebooks deployment (that assume all notebook repos are public) that controls the `tutorial-notebooks` folder so the new folder `pavics-homepage` has to be on its own and not under `tutorial-notebooks`.

If you absolutely want under `tutorial-notebooks`, I will have to migrate the existing notebooks deployment to use this new generic way to deploy anything, this will take much more time.

So the current config will check for changes and autodeploy every hour (`DEPLOY_DATA_JOB_SCHEDULE`).  I also added the `.geojson` data files.  If in the future there are new data file type, you can simply add the new extension to the list in `rsync_extra_opts`.

I tried to run all the notebooks and the `PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb` have this error `OSError: [Errno 30] Read-only file system: 'output'` at the last cell.

Have not had time to investigate but on the production Jupyter env, the `/pavics-homepage` dir is read-only so if you need to write some temporary file, you have to select another location, like under `/tmp` for example.

All other notebooks seem to work fine.

It's live on our staging https://medus.ouranos.ca/

![Screenshot from 2021-03-16 23-27-39](https://user-images.githubusercontent.com/11966697/111410728-a7f23800-86af-11eb-98d5-3ff82b0b760f.png)
