### PR TITLE
deploy pavics-landing: update to https repo url since the repo is now public

### DIFF
--- a/scheduler-jobs/deploy_pavics_landing_notebooks.env
+++ b/scheduler-jobs/deploy_pavics_landing_notebooks.env
@@ -9,7 +9,6 @@
 #
 ## Override cron schedule and set ssh identity file.
 #DEPLOY_DATA_JOB_SCHEDULE="3 0,3,6,9,12,15,18,21 * * *"  # UTC
-#DEPLOY_DATA_JOB_GIT_SSH_IDENTITY_FILE=/home/vagrant/.ssh/id_rsa_pavics-landing-ro
 #
 ## Source deploy_data_job.env that will actually perform the job creation.
 #. <path to deploy_data_job.env>

--- a/scheduler-jobs/deploy_pavics_landing_notebooks.yml
+++ b/scheduler-jobs/deploy_pavics_landing_notebooks.yml
@@ -4,8 +4,7 @@
 #
 
 deploy:
-  # clone over ssh since private repo
-- repo_url: git@github.com:Ouranosinc/PAVICS-landing.git
+- repo_url: https://github.com/Ouranosinc/PAVICS-landing.git
   branch: origin/master
   checkout_name: PAVICS-landing
   dir_maps:


### PR DESCRIPTION
This makes the cronjob setup easier since no ssh keys to worry about.

pavics-landing repo is made public for https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/79.