### PR TITLE
deploy-pavics-vdb-ncml: migrate from pavics-vdb repo to centralize all deployment jobs here

### DIFF
--- a/scheduler-jobs/deploy-pavics-vdb-ncml.env
+++ b/scheduler-jobs/deploy-pavics-vdb-ncml.env
@@ -1,0 +1,30 @@
+# Source this file in env.local before sourcing deploy_data_job.env.
+# This will configure deploy_data_job.env.
+
+#############
+## Sample way to override default configs in this file.
+#
+## Source this file providing default config values.
+#. <path to this file>
+#
+## Override cron schedule and set ssh identity file.
+#DEPLOY_DATA_JOB_SCHEDULE="3 0,3,6,9,12,15,18,21 * * *"  # UTC
+#DEPLOY_DATA_JOB_GIT_SSH_IDENTITY_FILE=/home/vagrant/.ssh/id_rsa_pavics-vdb-ro
+#
+## Set absolute path to config file if default path do not work inside container.
+#DEPLOY_DATA_JOB_CONFIG="/path/to/deploy-pavics-vdb-ncml.yml"
+#
+## Source deploy_data_job.env that will actually perform the job creation.
+#. <path to deploy_data_job.env>
+#
+## End Sample
+#############
+
+
+DEPLOY_DATA_JOB_SCHEDULE="23 * * * *"  # UTC
+DEPLOY_DATA_JOB_JOB_NAME="deploy-pavics-vdb-ncml"
+DEPLOY_DATA_JOB_CONFIG="${COMPOSE_DIR}/../../birdhouse-deploy-ouranos/scheduler-jobs/${DEPLOY_DATA_JOB_JOB_NAME}.yml"
+DEPLOY_DATA_JOB_JOB_DESCRIPTION="Deploy NcML files on Thredds."
+
+
+# vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/scheduler-jobs/deploy-pavics-vdb-ncml.yml
+++ b/scheduler-jobs/deploy-pavics-vdb-ncml.yml
@@ -1,0 +1,16 @@
+# Config file for deploy-data script to deploy NcML files.
+#
+# Use in deploy-pavics-vdb-ncml.env scheduler job.
+#
+
+deploy:
+  # clone over ssh since private repo
+- repo_url: git@github.com:Ouranosinc/pavics-vdb.git
+  branch: origin/master
+  checkout_name: pavics-vdb-for-ncml
+  dir_maps:
+  - source_dir: 1-Datasets/
+    dest_dir: /data/ncml/
+
+
+# vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2


### PR DESCRIPTION
This job was before the deploy-data generic deployment mechanism
existed.  Forgot it when all other jobs are ported to deploy-data.

Canarie presentation reminded me about this one.

By having this job here means we can centrally manage it via `env.local`
like all other jobs and any future updates will be deployed
automatically.

This old corresponding file will be deleted in PR https://github.com/Ouranosinc/pavics-vdb/pull/39
https://github.com/Ouranosinc/pavics-vdb/blob/ee65189f21dfe608f77c82d87a4e02237db2bf7a/deployment/deploy-pavics-vdb-ncml