### PR TITLE
Deploy catalog on PAVICS

### DIFF
--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -16,4 +16,6 @@ services:
 # be done.
 #    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/public-raven-bypass-twitcher.conf:/etc/nginx/conf.extra-service.d/raven/public-raven-bypass-twitcher.conf:ro
     - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/cruesdeca-redirect.conf:/etc/nginx/conf.extra-service.d/redirect/cruesdeca-redirect.conf:ro
-    - /data/homepage:/data/homepage:ro
+    - ${DATA_PERSIST_ROOT}/homepage:${DATA_PERSIST_ROOT}/homepage:ro
+    - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/catalog.conf:/etc/nginx/conf.extra-service.d/catalog/catalog.conf:ro
+    - ${DATA_PERSIST_ROOT}/catalog:${DATA_PERSIST_ROOT}/catalog:ro

--- a/ouranos-config/proxy/catalog.conf.template
+++ b/ouranos-config/proxy/catalog.conf.template
@@ -1,0 +1,3 @@
+    location /catalog {
+        alias ${DATA_PERSIST_ROOT}/catalog/;
+    }

--- a/ouranos-config/proxy/catalog.conf.template
+++ b/ouranos-config/proxy/catalog.conf.template
@@ -1,3 +1,6 @@
     location /catalog {
         alias ${DATA_PERSIST_ROOT}/catalog/;
+        autoindex on;  # allow directory browsing
+        autoindex_exact_size off;  # files size shown will be rounded to KB, MB or GB, more friendly than exact bytes
+        autoindex_localtime on;  # show files time as localtime instead of GMT
     }

--- a/ouranos-config/proxy/catalog.conf.template
+++ b/ouranos-config/proxy/catalog.conf.template
@@ -2,5 +2,5 @@
         alias ${DATA_PERSIST_ROOT}/catalog/;
         autoindex on;  # allow directory browsing
         autoindex_exact_size off;  # files size shown will be rounded to KB, MB or GB, more friendly than exact bytes
-        autoindex_localtime on;  # show files time as localtime instead of GMT
+        # autoindex_localtime on;  # show files time as localtime instead of GMT
     }

--- a/scheduler-jobs/gen_catalog.env
+++ b/scheduler-jobs/gen_catalog.env
@@ -1,0 +1,35 @@
+# Source this file in env.local before sourcing deploy_data_job.env.
+# This will configure deploy_data_job.env.
+
+#############
+## Sample way to override default configs in this file.
+#
+## Source this file providing default config values.
+#. <path to this file>
+#
+## Override cron schedule and set ssh identity file.
+#DEPLOY_DATA_JOB_SCHEDULE="3 0,3,6,9,12,15,18,21 * * *"  # UTC
+#DEPLOY_DATA_JOB_GIT_SSH_IDENTITY_FILE=/home/vagrant/.ssh/id_rsa_pavics-vdb-ro
+#
+## Set absolute path to config file if default path do not work inside container.
+#DEPLOY_DATA_JOB_CONFIG="/path/to/gen_catalog.yml"
+#
+## Source deploy_data_job.env that will actually perform the job creation.
+#. <path to deploy_data_job.env>
+#
+## End Sample
+#############
+
+
+DEPLOY_DATA_JOB_SCHEDULE="19 * * * *"  # UTC
+DEPLOY_DATA_JOB_JOB_NAME="gen_catalog"
+DEPLOY_DATA_JOB_CONFIG="${COMPOSE_DIR}/../../birdhouse-deploy-ouranos/scheduler-jobs/gen_catalog.yml"
+DEPLOY_DATA_JOB_JOB_DESCRIPTION="Generate Intake Catalog for data on Thredds."
+
+# Set good config file.
+# Can all be overridden by caller.
+DEPLOY_DATA_JOB_DOCKER_RUN_EXTRA_OPTS="
+    --env LAUNCH_CONTAINER_CONFIG_FILE=catalog/gen_catalog.conf $DEPLOY_DATA_JOB_DOCKER_RUN_EXTRA_OPTS"
+
+
+# vi: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/scheduler-jobs/gen_catalog.env
+++ b/scheduler-jobs/gen_catalog.env
@@ -4,18 +4,26 @@
 #############
 ## Sample way to override default configs in this file.
 #
-## Source this file providing default config values.
-#. <path to this file>
 #
-## Override cron schedule and set ssh identity file.
-#DEPLOY_DATA_JOB_SCHEDULE="3 0,3,6,9,12,15,18,21 * * *"  # UTC
-#DEPLOY_DATA_JOB_GIT_SSH_IDENTITY_FILE=/home/vagrant/.ssh/id_rsa_pavics-vdb-ro
+#COMPOSE_DIR="</path/to/checkout/birdhouse-deploy/birdhouse>"
+#CHECKOUT_OURANOS_CONFIG="</path/to/checkout/birdhouse-deploy-ouranos>"  # this repo
 #
-## Set absolute path to config file if default path do not work inside container.
-#DEPLOY_DATA_JOB_CONFIG="/path/to/gen_catalog.yml"
+#DEPLOY_DATA_JOB_ENV="$COMPOSE_DIR/components/scheduler/deploy_data_job.env"
+#GEN_CATALOG_JOB="$CHECKOUT_OURANOS_CONFIG/scheduler-jobs/gen_catalog.env"
 #
-## Source deploy_data_job.env that will actually perform the job creation.
-#. <path to deploy_data_job.env>
+#if [ -f "$DEPLOY_DATA_JOB_ENV" -a -f "$GEN_CATALOG_JOB" ]; then
+#  . $GEN_CATALOG_JOB
+#
+#  # Override cron schedule and set ssh identity file.
+#  DEPLOY_DATA_JOB_SCHEDULE="*/3 * * * *"  # UTC
+#  DEPLOY_DATA_JOB_GIT_SSH_IDENTITY_FILE=$AUTODEPLOY_DEPLOY_KEY_ROOT_DIR/id_rsa_pavics-vdb-ro
+#
+#  # Set absolute path to config file if default path do not work inside container.
+#  DEPLOY_DATA_JOB_CONFIG="$CHECKOUT_OURANOS_CONFIG/scheduler-jobs/gen_catalog.yml"
+#
+#  . $DEPLOY_DATA_JOB_ENV
+#fi
+#
 #
 ## End Sample
 #############

--- a/scheduler-jobs/gen_catalog.env
+++ b/scheduler-jobs/gen_catalog.env
@@ -30,7 +30,7 @@
 
 
 DEPLOY_DATA_JOB_SCHEDULE="19 * * * *"  # UTC
-DEPLOY_DATA_JOB_JOB_NAME="gen_catalog"
+DEPLOY_DATA_JOB_JOB_NAME="gen_catalog_job"
 DEPLOY_DATA_JOB_CONFIG="${COMPOSE_DIR}/../../birdhouse-deploy-ouranos/scheduler-jobs/gen_catalog.yml"
 DEPLOY_DATA_JOB_JOB_DESCRIPTION="Generate Intake Catalog for data on Thredds."
 

--- a/scheduler-jobs/gen_catalog.yml
+++ b/scheduler-jobs/gen_catalog.yml
@@ -1,0 +1,15 @@
+# Config file for deploy-data script to generate catalog files.
+#
+# Use in gen_catalog.env scheduler job.
+#
+
+deploy:
+  # clone over ssh since private repo
+- repo_url: git@github.com:Ouranosinc/pavics-vdb.git
+  branch: origin/master
+  checkout_name: pavics-vdb-for-catalog
+  post_actions:
+  - action: deployment/launch_container
+
+
+# vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2


### PR DESCRIPTION
Setup cronjob to hourly re-generate the catalog and will be available at https://pavics.ouranos.ca/catalog/.

Test server: https://lvupavicsdev.ouranos.ca/catalog/.  The `/catalog` part can be changed easily if not suitable.

Leverage existing generic deploy anything code that was used for GEPS forecast.  There are no new code, it's just a bunch of new configs.

Matching pavics-vdb PR https://github.com/Ouranosinc/pavics-vdb/pull/40 for reproducible runtime env.

Task left from https://github.com/Ouranosinc/pavics-vdb/pull/26.
