### PR TITLE
deploy pavics-landing: add Jupyter env Readme deployment

### DIFF
--- a/scheduler-jobs/deploy_pavics_landing_notebooks.yml
+++ b/scheduler-jobs/deploy_pavics_landing_notebooks.yml
@@ -14,6 +14,8 @@ deploy:
     rsync_extra_opts: --include=*/ --include=*.ipynb --include=*.geojson --exclude=*
   - source_dir: src
     dest_dir: /data/homepage
+  - source_dir: content/jupyter-readme
+    dest_dir: /data/jupyterhub_user_data/jupyter-readme
 
 
 # vi: tabstop=8 expandtab shiftwidth=2 softtabstop=2


### PR DESCRIPTION
Match PR https://github.com/Ouranosinc/PAVICS-landing/pull/31 that moved the `README.ipynb` file outside of birdhouse-deploy repo.

Match PR https://github.com/bird-house/birdhouse-deploy/pull/190 that deleted the deployment of `README.ipynb` at the old location.