### PR TITLE
pavics-landing tuto nb job: fix missing file in tutorial_data/

### DIFF
--- a/scheduler-jobs/deploy_pavics_landing_notebooks.yml
+++ b/scheduler-jobs/deploy_pavics_landing_notebooks.yml
@@ -11,7 +11,7 @@ deploy:
   # rsync content below source_dir into dest_dir
   - source_dir: content/notebooks/climate_indicators
     dest_dir: /data/jupyterhub_user_data/pavics-homepage
-    rsync_extra_opts: --include=*/ --include=*.ipynb --include=*.geojson --exclude=*
+    rsync_extra_opts: --include=*/ --include=*.ipynb --include=tutorial_data/** --exclude=*
   - source_dir: src
     dest_dir: /data/homepage
   - source_dir: content/jupyter-readme


### PR DESCRIPTION
All of `tutorial_data/` will now be deployed so future files will be transparently handled.

Fixes https://github.com/Ouranosinc/PAVICS-landing/issues/89.