### PR TITLE
Create Magpie groups to ease administration

### DIFF
--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -19,6 +19,10 @@ services:
     - ${DATA_PERSIST_ROOT}/catalog:${DATA_PERSIST_ROOT}/catalog:ro
     - ../../birdhouse-deploy-ouranos/ouranos-config/proxy/ogc-geoserver.conf:/etc/nginx/conf.extra-service.d/ogc/ogc-geoserver.conf:ro
 
+  magpie:
+    volumes:
+      - ../../birdhouse-deploy-ouranos/ouranos-config/magpie/ouranos-permissions.yml:${MAGPIE_PERMISSIONS_CONFIG_PATH}/ouranos-permissions.yml:ro
+
   jupyterhub:
     volumes:
     # So that in jupyterhub_config.py, we can do

--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -22,6 +22,7 @@ services:
   magpie:
     volumes:
       - ../../birdhouse-deploy-ouranos/ouranos-config/magpie/ouranos-permissions.yml:${MAGPIE_PERMISSIONS_CONFIG_PATH}/ouranos-permissions.yml:ro
+      - ../../birdhouse-deploy-ouranos/ouranos-config/magpie/ouranos-permissions.yml:${MAGPIE_PROVIDERS_CONFIG_PATH}/ouranos-permissions.yml:ro
 
   jupyterhub:
     volumes:

--- a/ouranos-config/docker-compose-extra.yml
+++ b/ouranos-config/docker-compose-extra.yml
@@ -22,7 +22,6 @@ services:
   magpie:
     volumes:
       - ../../birdhouse-deploy-ouranos/ouranos-config/magpie/ouranos-permissions.yml:${MAGPIE_PERMISSIONS_CONFIG_PATH}/ouranos-permissions.yml:ro
-      - ../../birdhouse-deploy-ouranos/ouranos-config/magpie/ouranos-permissions.yml:${MAGPIE_PROVIDERS_CONFIG_PATH}/ouranos-permissions.yml:ro
 
   jupyterhub:
     volumes:

--- a/ouranos-config/magpie/.gitignore
+++ b/ouranos-config/magpie/.gitignore
@@ -1,0 +1,1 @@
+ouranos-permissions.yml

--- a/ouranos-config/magpie/ouranos-permissions.yml.template
+++ b/ouranos-config/magpie/ouranos-permissions.yml.template
@@ -1,17 +1,19 @@
 # Reference https://github.com/Ouranosinc/Magpie/blob/master/config/permissions.cfg
 
-# Create groups to ease administration of the growing number of users.
+# Description of groups to ease administration of the growing number of users.
+#
+# This do not create the groups.  The group is created only if the permissions
+# below reference them and need to be created.
 groups:
   - name: deny_jupyter_login
     description: "Users in this group will be blocked from login to Jupyter"
-    action: create
 
   - name: bogus_email_users
     description: "Users with bogus emails, typically test users or bulk temporary users, these emails should be excluded when sending Jupyter env notification"
-    action: create
 
 
-# Apply permissions to groups above.
+# Add permissions, not existing group will be recreated with the infos above.
+# Meaning if no permissions reference the group, the group will not be created.
 permissions:
   - service: jupyterhub
     type: api
@@ -23,4 +25,12 @@ permissions:
     type: api
     permission: write-deny-recursive
     group: deny_jupyter_login
+    action: create
+
+  # Bogus permission, taken from optional-components/secure-thredds just to force group creation.
+  - service: thredds
+    resource: /${THREDDS_SERVICE_DATA_URL_PATH}/testdata/secure
+    type: directory
+    permission: read-deny-recursive
+    group: bogus_email_users
     action: create

--- a/ouranos-config/magpie/ouranos-permissions.yml.template
+++ b/ouranos-config/magpie/ouranos-permissions.yml.template
@@ -1,11 +1,15 @@
 # Reference https://github.com/Ouranosinc/Magpie/blob/master/config/permissions.cfg
 
-# Create group.
+# Create groups to ease administration of the growing number of users.
 groups:
   - name: deny_jupyter_login
     description: "Users in this group will be blocked from login to Jupyter"
 
-# Apply permissions to group.
+  - name: bogus_email_users
+    description: "Users with bogus emails, typically test users or bulk temporary users, these emails should be excluded when sending Jupyter env notification"
+
+
+# Apply permissions to groups above.
 permissions:
   - service: jupyterhub
     type: api

--- a/ouranos-config/magpie/ouranos-permissions.yml.template
+++ b/ouranos-config/magpie/ouranos-permissions.yml.template
@@ -4,9 +4,11 @@
 groups:
   - name: deny_jupyter_login
     description: "Users in this group will be blocked from login to Jupyter"
+    action: create
 
   - name: bogus_email_users
     description: "Users with bogus emails, typically test users or bulk temporary users, these emails should be excluded when sending Jupyter env notification"
+    action: create
 
 
 # Apply permissions to groups above.

--- a/ouranos-config/magpie/ouranos-permissions.yml.template
+++ b/ouranos-config/magpie/ouranos-permissions.yml.template
@@ -9,7 +9,7 @@ groups:
     description: "Users in this group will be blocked from login to Jupyter"
 
   - name: bogus_email_users
-    description: "Users with bogus emails, typically test users or bulk temporary users, these emails should be excluded when sending Jupyter env notification"
+    description: "Users with bogus emails excluded when sending Jupyter notification"
 
 
 # Add permissions, not existing group will be recreated with the infos above.

--- a/ouranos-config/magpie/ouranos-permissions.yml.template
+++ b/ouranos-config/magpie/ouranos-permissions.yml.template
@@ -1,4 +1,5 @@
 # Reference https://github.com/Ouranosinc/Magpie/blob/master/config/permissions.cfg
+# Online doc https://pavics-magpie.readthedocs.io/en/latest/api.html
 
 # Description of groups to ease administration of the growing number of users.
 #
@@ -9,6 +10,7 @@ groups:
     description: "Users in this group will be blocked from login to Jupyter"
 
   - name: bogus_email_users
+    # Description length can not be too long.
     description: "Users with bogus emails excluded when sending Jupyter notification"
 
 

--- a/ouranos-config/magpie/ouranos-permissions.yml.template
+++ b/ouranos-config/magpie/ouranos-permissions.yml.template
@@ -7,7 +7,8 @@ groups:
     action: create
 
   - name: bogus_email_users
-    description: "Users with bogus emails, typically test users or bulk temporary users, these emails should be excluded when sending Jupyter env notification"
+    # Description can not have '-', '_', ',', looks like only [:alphanum:] is allowed.
+    description: "Users with bogus emails to be excluded when sending Jupyter env notification"
     action: create
 
 

--- a/ouranos-config/magpie/ouranos-permissions.yml.template
+++ b/ouranos-config/magpie/ouranos-permissions.yml.template
@@ -1,0 +1,20 @@
+# Reference https://github.com/Ouranosinc/Magpie/blob/master/config/permissions.cfg
+
+# Create group.
+groups:
+  - name: deny_jupyter_login
+    description: "Users in this group will be blocked from login to Jupyter"
+
+# Apply permissions to group.
+permissions:
+  - service: jupyterhub
+    type: api
+    permission: read-deny-recursive
+    group: deny_jupyter_login
+    action: create
+
+  - service: jupyterhub
+    type: api
+    permission: write-deny-recursive
+    group: deny_jupyter_login
+    action: create

--- a/ouranos-config/magpie/ouranos-permissions.yml.template
+++ b/ouranos-config/magpie/ouranos-permissions.yml.template
@@ -7,8 +7,7 @@ groups:
     action: create
 
   - name: bogus_email_users
-    # Description can not have '-', '_', ',', looks like only [:alphanum:] is allowed.
-    description: "Users with bogus emails to be excluded when sending Jupyter env notification"
+    description: "Users with bogus emails, typically test users or bulk temporary users, these emails should be excluded when sending Jupyter env notification"
     action: create
 
 


### PR DESCRIPTION
Group description shows the intention of the group.

Adding members to these new groups will done via API because the yml config syntax do not allow for adding supplemental groups to existing users.
